### PR TITLE
Ajout de l'affichage du temps en cours au sein de la mesure

### DIFF
--- a/Aiguille.qml
+++ b/Aiguille.qml
@@ -22,11 +22,11 @@ Image {
 
     function actualisePosition ()
     {
-        if (angleEnCours<angleMax) {
-            angleEnCours=angleMax
-        }
-        else if (angleEnCours>angleMin) {
+        if (angleEnCours>angleMin) {
             angleEnCours=angleMin
+        }
+        else if (angleEnCours<angleMax) {
+            angleEnCours=angleMax
         }
         rotationAiguille.angle= angleEnCours
         console.log ("Rotation de l'aiguille sur l'angle %1".arg (angleEnCours))

--- a/TempsMesure.qml
+++ b/TempsMesure.qml
@@ -1,0 +1,29 @@
+import QtQuick 2.0
+import QtQuick.Layouts 1.3
+
+RowLayout {
+    id: tempsMesure
+
+    property int tempsEnCours: 1
+    property int tempsParMesure: 4
+
+    spacing: 3
+
+    visible: (tempsParMesure<=12)
+
+    Repeater {
+        model: tempsParMesure
+
+        Rectangle {
+            id: temps1
+
+            width: 8
+            height: 8
+            color: (tempsEnCours===index+1)?"black": "transparent"
+            border.color: "black"
+            border.width: 1
+            radius: 4
+            visible: (tempsParMesure>=index)
+        }
+    }
+}

--- a/metronome.qml
+++ b/metronome.qml
@@ -7,6 +7,7 @@ Rectangle {
     property int marge: 10
     property int bpm: 60
     property int tempsParMesure: 2
+    property int temps: 0
     property alias timer: timerMetronome
     property alias enMarche: timerMetronome.running
 
@@ -48,9 +49,18 @@ Rectangle {
             id: affichageAiguille
 
             x: fondMetronome.bordGaucheEcran+(fondMetronome.bordDroitEcran-fondMetronome.bordGaucheEcran)/2
-            y: fondMetronome.bordBasEcran
+            y: fondMetronome.bordBasEcran - 10
 
             visible: metronome.enMarche
+        }
+
+        TempsMesure {
+            id: tempsMesure
+
+            x: fondMetronome.bordGaucheEcran
+            y: fondMetronome.bordBasEcran - height
+            tempsEnCours: temps
+            tempsParMesure: metronome.tempsParMesure
         }
 
         Text {
@@ -65,13 +75,12 @@ Rectangle {
     Timer {
         id: timerMetronome
 
-        property int temps: 0
 
         interval: 60000/bpm
         repeat: true
         onTriggered: {
-            temps = temps+1
-            temps=(temps>metronome.tempsParMesure) ? 1 : temps
+            metronome.temps = metronome.temps+1
+            metronome.temps=(metronome.temps>metronome.tempsParMesure) ? 1 : metronome.temps
             jouerSon()
             affichageAiguille.actualisePosition ()
         }
@@ -88,8 +97,9 @@ Rectangle {
     }
 
     function marche() {
-        timerMetronome.temps= 0
+        temps= 0
         timerMetronome.start()
+        affichageAiguille.angleEnCours=180
         console.log("Mise en route du métronome !")
     }
 
@@ -99,7 +109,7 @@ Rectangle {
     }
 
     function jouerSon () {
-        var tempsEnCours = timerMetronome.temps
+        var tempsEnCours = temps
         if ((tempsEnCours==1) && (metronome.tempsParMesure>1))
             sonClair.play ()
         else

--- a/qml.qrc
+++ b/qml.qrc
@@ -4,6 +4,7 @@
         <file>Metronome.qml</file>
         <file>MainForm.qml</file>
         <file>Aiguille.qml</file>
+        <file>TempsMesure.qml</file>
     </qresource>
     <qresource prefix="/Images">
         <file>images/aiguille.png</file>


### PR DESCRIPTION
Affichage du temps en cours au sein de la mesure par un cercle plein (temps en cours) et des cercles vides (les autres)

Correctif aiguille pour qu'elle débute bien sur le bord gauche du métronome et remontée de son affichage de 10 pixels pour laisser la place à la gestion du temps en cours
